### PR TITLE
Security Export: Issues, Dependabot & CodeScan Alerts (2026-06-29)

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -5,67 +5,70 @@
 | Metric | Value |
 |--------|-------|
 | ⭐ Stars | 63 |
-| 📥 Clones (last 14 days) | 202 |
-| 🟢 Open Issues | 50 |
+| 📥 Clones (last 14 days) | 238 |
+| 🟢 Open Issues | 0 |
 | 📋 Total Issues | 50 |
 | 🛡 Dependabot Open Alerts | 0 |
-| 🔍 CodeScan Open Alerts | 15 |
+| 🔍 CodeScan Open Alerts | 14 |
 
 ## Issues
-- [#50](./issue_50.md) - RUN_STREAM_JOBS and DISCOVER_JOBS hold BufferedEventSink objects indefinitely — memory exhaustion via sustained job creation (open)
-- [#49](./issue_49.md) - estorides_core/config.py creates filesystem directories at module import time — violates project's own hard rules (open)
-- [#48](./issue_48.md) - Audit log (data/audit.jsonl) has no rotation, size cap, or retention policy — unbounded growth and privacy risk (open)
-- [#47](./issue_47.md) - /api/graph serves the last operator's full intelligence graph without authentication or session isolation (open)
-- [#46](./issue_46.md) - Latent Cypher injection in KuzuGraphBackend.neighbors() via unsanitised relation parameter (open)
-- [#45](./issue_45.md) - WiGLE source references non-existent env var WIGLE_API_NAME_WIGLE_API_API_KEY — source never authenticates (open)
-- [#44](./issue_44.md) - Internal exception details (file paths, schema names, query fragments) returned to unauthenticated API clients (open)
-- [#43](./issue_43.md) - /api/export/<fmt> creates permanent unbounded files in reports/ — unauthenticated disk exhaustion attack (open)
-- [#42](./issue_42.md) - _multi_test.sh hardcodes developer's home directory path, breaking all end-to-end tests for every other user (open)
-- [#41](./issue_41.md) - CSP includes style-src 'unsafe-inline', enabling CSS injection and data exfiltration from intelligence reports (open)
-- [#40](./issue_40.md) - All dependencies are unpinned (>=only) with no lockfile; multiple CVE ranges are reachable (aiohttp, gunicorn) (open)
-- [#39](./issue_39.md) - GitHub Actions workflow is a non-functional demo; Dependabot is misconfigured with an empty package-ecosystem (open)
-- [#38](./issue_38.md) - In-process rate limiter is multiplied by gunicorn worker count — effective limit is N_workers × 30/min (open)
-- [#37](./issue_37.md) - Reddit sources scrape the JSON API without OAuth, violating Reddit's ToS and causing IP blocking (open)
-- [#36](./issue_36.md) - Bare int() casts on user-controlled query parameters cause unhandled ValueError (500) on four endpoints (open)
-- [#35](./issue_35.md) - /api/graph, /api/status, and all /api/discover/* endpoints are missing rate limiting (open)
-- [#34](./issue_34.md) - Stored XSS via unescaped entity.type field in innerHTML template literals (open)
-- [#33](./issue_33.md) - Real OSINT investigation data (IPs, domains) committed to git in reports/bundle_1780871293.json (open)
-- [#32](./issue_32.md) - [CRITICAL] #3: Unsafe LLM timeout handling causes race condition (open)
-- [#31](./issue_31.md) - Public /api/osiris/* endpoints turn the deployment into an unauthenticated third-party reconnaissance relay (open)
-- [#30](./issue_30.md) - Unauthenticated /api/transform/run turns resolver, VirusTotal, GitHub, and breach lookups into a public enrichment relay (open)
-- [#29](./issue_29.md) - Unauthenticated /api/intel/stats leaks corpus size and internal database paths (open)
-- [#28](./issue_28.md) - /api/intel/graph accepts arbitrary expensive Cypher with no server-side timeout or enforced row cap (open)
-- [#27](./issue_27.md) - Unauthenticated /api/intel/graph exposes the persistent intelligence graph through arbitrary read-only Cypher (open)
-- [#26](./issue_26.md) - Unauthenticated /api/intel/resolve leaks cross-run intelligence and can spend VirusTotal quota (open)
-- [#25](./issue_25.md) - exif_remove_lookup is misclassified as contact=none even though the provider fetches the submitted image URL (open)
-- [#24](./issue_24.md) - pages_dev_meta is misclassified as contact=none even though Microlink fetches the submitted target URL (open)
-- [#23](./issue_23.md) - microlink is misclassified as contact=none even though it fetches and screenshots target URLs (open)
-- [#22](./issue_22.md) - screenshotmachine is misclassified as contact=none even though the provider fetches target URLs (open)
-- [#21](./issue_21.md) - tineye_reverse is misclassified as contact=none even though TinEye actively fetches the target URL (open)
-- [#20](./issue_20.md) - DISCOVER_JOBS is never evicted, allowing anonymous callers to retain unbounded job state in memory (open)
-- [#19](./issue_19.md) - Unauthenticated /api/discover/stop lets any caller cancel discovery jobs (open)
-- [#18](./issue_18.md) - Unauthenticated /api/discover/stream leaks live discovery events and case IDs (open)
-- [#17](./issue_17.md) - Unauthenticated /api/discover/jobs discloses every active discovery job and seed (open)
-- [#16](./issue_16.md) - Minimal-install deployments crash /api/discover/start when kuzu is absent (open)
-- [#15](./issue_15.md) - Unauthenticated /api/discover/start lets arbitrary callers queue background discovery crawls (open)
-- [#14](./issue_14.md) - RUN_STREAM_JOBS is never evicted, so anonymous callers can grow server memory without bound (open)
-- [#13](./issue_13.md) - Unauthenticated /api/run/stream/stop lets any caller cancel another user's deep search (open)
-- [#12](./issue_12.md) - Unauthenticated /api/run/stream leaks live deep-search events and case IDs (open)
-- [#11](./issue_11.md) - Unauthenticated /api/run/stream/start lets any caller launch deep recursive cross-search jobs (open)
-- [#10](./issue_10.md) - Client-controlled parallel, timeout, and deadline values make /api/run a single-request resource exhaustion primitive (open)
-- [#9](./issue_9.md) - Unauthenticated /api/run allows arbitrary callers to burn paid-source keys and upstream quota (open)
-- [#8](./issue_8.md) - Encrypted export leaves plaintext intelligence artifacts on disk in reports/ (open)
-- [#7](./issue_7.md) - Unauthenticated /api/export/<fmt> lets any caller download shared investigation artifacts (open)
-- [#6](./issue_6.md) - Shared global GraphML file lets /api/graph disclose the last user's investigation (open)
-- [#5](./issue_5.md) - Unauthenticated /api/cases/diff reveals deltas between arbitrary investigations (open)
-- [#4](./issue_4.md) - Unauthenticated POST /api/cases/<id>/save lets any caller overwrite case notes (open)
-- [#3](./issue_3.md) - Unauthenticated DELETE /api/cases/<id> lets any caller destroy persisted investigations (open)
-- [#2](./issue_2.md) - Unauthenticated /api/cases/<id>?full=1 exposes raw observations, entities, and analyst output (open)
-- [#1](./issue_1.md) - Unauthenticated /api/cases leaks the full historical investigation corpus (open)
+- [#50](./issue_50.md) - RUN_STREAM_JOBS and DISCOVER_JOBS hold BufferedEventSink objects indefinitely — memory exhaustion via sustained job creation (closed)
+- [#49](./issue_49.md) - estorides_core/config.py creates filesystem directories at module import time — violates project's own hard rules (closed)
+- [#48](./issue_48.md) - Audit log (data/audit.jsonl) has no rotation, size cap, or retention policy — unbounded growth and privacy risk (closed)
+- [#47](./issue_47.md) - /api/graph serves the last operator's full intelligence graph without authentication or session isolation (closed)
+- [#46](./issue_46.md) - Latent Cypher injection in KuzuGraphBackend.neighbors() via unsanitised relation parameter (closed)
+- [#45](./issue_45.md) - WiGLE source references non-existent env var WIGLE_API_NAME_WIGLE_API_API_KEY — source never authenticates (closed)
+- [#44](./issue_44.md) - Internal exception details (file paths, schema names, query fragments) returned to unauthenticated API clients (closed)
+- [#43](./issue_43.md) - /api/export/<fmt> creates permanent unbounded files in reports/ — unauthenticated disk exhaustion attack (closed)
+- [#42](./issue_42.md) - _multi_test.sh hardcodes developer's home directory path, breaking all end-to-end tests for every other user (closed)
+- [#41](./issue_41.md) - CSP includes style-src 'unsafe-inline', enabling CSS injection and data exfiltration from intelligence reports (closed)
+- [#40](./issue_40.md) - All dependencies are unpinned (>=only) with no lockfile; multiple CVE ranges are reachable (aiohttp, gunicorn) (closed)
+- [#39](./issue_39.md) - GitHub Actions workflow is a non-functional demo; Dependabot is misconfigured with an empty package-ecosystem (closed)
+- [#38](./issue_38.md) - In-process rate limiter is multiplied by gunicorn worker count — effective limit is N_workers × 30/min (closed)
+- [#37](./issue_37.md) - Reddit sources scrape the JSON API without OAuth, violating Reddit's ToS and causing IP blocking (closed)
+- [#36](./issue_36.md) - Bare int() casts on user-controlled query parameters cause unhandled ValueError (500) on four endpoints (closed)
+- [#35](./issue_35.md) - /api/graph, /api/status, and all /api/discover/* endpoints are missing rate limiting (closed)
+- [#34](./issue_34.md) - Stored XSS via unescaped entity.type field in innerHTML template literals (closed)
+- [#33](./issue_33.md) - Real OSINT investigation data (IPs, domains) committed to git in reports/bundle_1780871293.json (closed)
+- [#32](./issue_32.md) - [CRITICAL] #3: Unsafe LLM timeout handling causes race condition (closed)
+- [#31](./issue_31.md) - Public /api/osiris/* endpoints turn the deployment into an unauthenticated third-party reconnaissance relay (closed)
+- [#30](./issue_30.md) - Unauthenticated /api/transform/run turns resolver, VirusTotal, GitHub, and breach lookups into a public enrichment relay (closed)
+- [#29](./issue_29.md) - Unauthenticated /api/intel/stats leaks corpus size and internal database paths (closed)
+- [#28](./issue_28.md) - /api/intel/graph accepts arbitrary expensive Cypher with no server-side timeout or enforced row cap (closed)
+- [#27](./issue_27.md) - Unauthenticated /api/intel/graph exposes the persistent intelligence graph through arbitrary read-only Cypher (closed)
+- [#26](./issue_26.md) - Unauthenticated /api/intel/resolve leaks cross-run intelligence and can spend VirusTotal quota (closed)
+- [#25](./issue_25.md) - exif_remove_lookup is misclassified as contact=none even though the provider fetches the submitted image URL (closed)
+- [#24](./issue_24.md) - pages_dev_meta is misclassified as contact=none even though Microlink fetches the submitted target URL (closed)
+- [#23](./issue_23.md) - microlink is misclassified as contact=none even though it fetches and screenshots target URLs (closed)
+- [#22](./issue_22.md) - screenshotmachine is misclassified as contact=none even though the provider fetches target URLs (closed)
+- [#21](./issue_21.md) - tineye_reverse is misclassified as contact=none even though TinEye actively fetches the target URL (closed)
+- [#20](./issue_20.md) - DISCOVER_JOBS is never evicted, allowing anonymous callers to retain unbounded job state in memory (closed)
+- [#19](./issue_19.md) - Unauthenticated /api/discover/stop lets any caller cancel discovery jobs (closed)
+- [#18](./issue_18.md) - Unauthenticated /api/discover/stream leaks live discovery events and case IDs (closed)
+- [#17](./issue_17.md) - Unauthenticated /api/discover/jobs discloses every active discovery job and seed (closed)
+- [#16](./issue_16.md) - Minimal-install deployments crash /api/discover/start when kuzu is absent (closed)
+- [#15](./issue_15.md) - Unauthenticated /api/discover/start lets arbitrary callers queue background discovery crawls (closed)
+- [#14](./issue_14.md) - RUN_STREAM_JOBS is never evicted, so anonymous callers can grow server memory without bound (closed)
+- [#13](./issue_13.md) - Unauthenticated /api/run/stream/stop lets any caller cancel another user's deep search (closed)
+- [#12](./issue_12.md) - Unauthenticated /api/run/stream leaks live deep-search events and case IDs (closed)
+- [#11](./issue_11.md) - Unauthenticated /api/run/stream/start lets any caller launch deep recursive cross-search jobs (closed)
+- [#10](./issue_10.md) - Client-controlled parallel, timeout, and deadline values make /api/run a single-request resource exhaustion primitive (closed)
+- [#9](./issue_9.md) - Unauthenticated /api/run allows arbitrary callers to burn paid-source keys and upstream quota (closed)
+- [#8](./issue_8.md) - Encrypted export leaves plaintext intelligence artifacts on disk in reports/ (closed)
+- [#7](./issue_7.md) - Unauthenticated /api/export/<fmt> lets any caller download shared investigation artifacts (closed)
+- [#6](./issue_6.md) - Shared global GraphML file lets /api/graph disclose the last user's investigation (closed)
+- [#5](./issue_5.md) - Unauthenticated /api/cases/diff reveals deltas between arbitrary investigations (closed)
+- [#4](./issue_4.md) - Unauthenticated POST /api/cases/<id>/save lets any caller overwrite case notes (closed)
+- [#3](./issue_3.md) - Unauthenticated DELETE /api/cases/<id> lets any caller destroy persisted investigations (closed)
+- [#2](./issue_2.md) - Unauthenticated /api/cases/<id>?full=1 exposes raw observations, entities, and analyst output (closed)
+- [#1](./issue_1.md) - Unauthenticated /api/cases leaks the full historical investigation corpus (closed)
 
 ## Code Scanning Alerts
+- [CodeScan #20](./codescan/alert_20.md) - js/xss-through-dom (warning) - open
+- [CodeScan #19](./codescan/alert_19.md) - py/stack-trace-exposure (error) - open
+- [CodeScan #18](./codescan/alert_18.md) - py/stack-trace-exposure (error) - open
+- [CodeScan #17](./codescan/alert_17.md) - actions/missing-workflow-permissions (warning) - open
 - [CodeScan #16](./codescan/alert_16.md) - js/xss-through-dom (warning) - open
-- [CodeScan #15](./codescan/alert_15.md) - js/xss-through-dom (warning) - open
 - [CodeScan #13](./codescan/alert_13.md) - py/incomplete-url-substring-sanitization (warning) - open
 - [CodeScan #12](./codescan/alert_12.md) - py/incomplete-url-substring-sanitization (warning) - open
 - [CodeScan #11](./codescan/alert_11.md) - py/url-redirection (error) - open
@@ -75,9 +78,5 @@
 - [CodeScan #7](./codescan/alert_7.md) - py/stack-trace-exposure (error) - open
 - [CodeScan #6](./codescan/alert_6.md) - py/stack-trace-exposure (error) - open
 - [CodeScan #5](./codescan/alert_5.md) - py/stack-trace-exposure (error) - open
-- [CodeScan #4](./codescan/alert_4.md) - py/stack-trace-exposure (error) - open
-- [CodeScan #3](./codescan/alert_3.md) - py/stack-trace-exposure (error) - open
-- [CodeScan #2](./codescan/alert_2.md) - py/stack-trace-exposure (error) - open
-- [CodeScan #1](./codescan/alert_1.md) - py/stack-trace-exposure (error) - open
 
 Total issues downloaded: 50

--- a/issues/codescan/alert_17.md
+++ b/issues/codescan/alert_17.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #17: actions/missing-workflow-permissions
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-29T16:25:05Z
+- **URL:** https://github.com/grisuno/estorides/security/code-scanning/17
+
+## Description
+Workflow does not contain permissions

--- a/issues/codescan/alert_18.md
+++ b/issues/codescan/alert_18.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #18: py/stack-trace-exposure
+
+- **State:** open
+- **Severity:** error
+- **Tool:** CodeQL
+- **Created:** 2026-06-29T16:28:55Z
+- **URL:** https://github.com/grisuno/estorides/security/code-scanning/18
+
+## Description
+Information exposure through an exception

--- a/issues/codescan/alert_19.md
+++ b/issues/codescan/alert_19.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #19: py/stack-trace-exposure
+
+- **State:** open
+- **Severity:** error
+- **Tool:** CodeQL
+- **Created:** 2026-06-29T16:28:55Z
+- **URL:** https://github.com/grisuno/estorides/security/code-scanning/19
+
+## Description
+Information exposure through an exception

--- a/issues/codescan/alert_20.md
+++ b/issues/codescan/alert_20.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #20: js/xss-through-dom
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-29T17:13:26Z
+- **URL:** https://github.com/grisuno/estorides/security/code-scanning/20
+
+## Description
+DOM text reinterpreted as HTML

--- a/issues/issue_1.md
+++ b/issues/issue_1.md
@@ -1,8 +1,8 @@
 # Issue #1: Unauthenticated /api/cases leaks the full historical investigation corpus
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:33Z
-- **Updated:** 2026-06-08T10:26:33Z
+- **Updated:** 2026-06-29T15:46:22Z
 - **Labels:** None
 
 ---

--- a/issues/issue_10.md
+++ b/issues/issue_10.md
@@ -1,8 +1,8 @@
 # Issue #10: Client-controlled parallel, timeout, and deadline values make /api/run a single-request resource exhaustion primitive
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:48Z
-- **Updated:** 2026-06-08T10:26:48Z
+- **Updated:** 2026-06-29T15:58:14Z
 - **Labels:** None
 
 ---

--- a/issues/issue_11.md
+++ b/issues/issue_11.md
@@ -1,8 +1,8 @@
 # Issue #11: Unauthenticated /api/run/stream/start lets any caller launch deep recursive cross-search jobs
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:49Z
-- **Updated:** 2026-06-08T10:26:49Z
+- **Updated:** 2026-06-29T15:59:22Z
 - **Labels:** None
 
 ---

--- a/issues/issue_12.md
+++ b/issues/issue_12.md
@@ -1,8 +1,8 @@
 # Issue #12: Unauthenticated /api/run/stream leaks live deep-search events and case IDs
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:51Z
-- **Updated:** 2026-06-08T10:26:51Z
+- **Updated:** 2026-06-29T16:00:37Z
 - **Labels:** None
 
 ---

--- a/issues/issue_13.md
+++ b/issues/issue_13.md
@@ -1,8 +1,8 @@
 # Issue #13: Unauthenticated /api/run/stream/stop lets any caller cancel another user's deep search
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:52Z
-- **Updated:** 2026-06-08T10:26:52Z
+- **Updated:** 2026-06-29T16:00:39Z
 - **Labels:** None
 
 ---

--- a/issues/issue_14.md
+++ b/issues/issue_14.md
@@ -1,8 +1,8 @@
 # Issue #14: RUN_STREAM_JOBS is never evicted, so anonymous callers can grow server memory without bound
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:54Z
-- **Updated:** 2026-06-08T10:26:54Z
+- **Updated:** 2026-06-29T16:06:41Z
 - **Labels:** None
 
 ---

--- a/issues/issue_15.md
+++ b/issues/issue_15.md
@@ -1,8 +1,8 @@
 # Issue #15: Unauthenticated /api/discover/start lets arbitrary callers queue background discovery crawls
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:55Z
-- **Updated:** 2026-06-08T10:26:55Z
+- **Updated:** 2026-06-29T16:08:15Z
 - **Labels:** None
 
 ---

--- a/issues/issue_16.md
+++ b/issues/issue_16.md
@@ -1,8 +1,8 @@
 # Issue #16: Minimal-install deployments crash /api/discover/start when kuzu is absent
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:57Z
-- **Updated:** 2026-06-08T10:26:57Z
+- **Updated:** 2026-06-29T16:09:10Z
 - **Labels:** None
 
 ---

--- a/issues/issue_17.md
+++ b/issues/issue_17.md
@@ -1,8 +1,8 @@
 # Issue #17: Unauthenticated /api/discover/jobs discloses every active discovery job and seed
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:59Z
-- **Updated:** 2026-06-08T10:26:59Z
+- **Updated:** 2026-06-29T16:08:19Z
 - **Labels:** None
 
 ---

--- a/issues/issue_18.md
+++ b/issues/issue_18.md
@@ -1,8 +1,8 @@
 # Issue #18: Unauthenticated /api/discover/stream leaks live discovery events and case IDs
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:27:00Z
-- **Updated:** 2026-06-08T10:27:00Z
+- **Updated:** 2026-06-29T16:08:20Z
 - **Labels:** None
 
 ---

--- a/issues/issue_19.md
+++ b/issues/issue_19.md
@@ -1,8 +1,8 @@
 # Issue #19: Unauthenticated /api/discover/stop lets any caller cancel discovery jobs
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:27:02Z
-- **Updated:** 2026-06-08T10:27:02Z
+- **Updated:** 2026-06-29T16:08:22Z
 - **Labels:** None
 
 ---

--- a/issues/issue_2.md
+++ b/issues/issue_2.md
@@ -1,8 +1,8 @@
 # Issue #2: Unauthenticated /api/cases/<id>?full=1 exposes raw observations, entities, and analyst output
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:35Z
-- **Updated:** 2026-06-08T10:26:35Z
+- **Updated:** 2026-06-29T15:47:39Z
 - **Labels:** None
 
 ---

--- a/issues/issue_20.md
+++ b/issues/issue_20.md
@@ -1,8 +1,8 @@
 # Issue #20: DISCOVER_JOBS is never evicted, allowing anonymous callers to retain unbounded job state in memory
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:27:04Z
-- **Updated:** 2026-06-08T10:27:04Z
+- **Updated:** 2026-06-29T16:06:43Z
 - **Labels:** None
 
 ---

--- a/issues/issue_21.md
+++ b/issues/issue_21.md
@@ -1,8 +1,8 @@
 # Issue #21: tineye_reverse is misclassified as contact=none even though TinEye actively fetches the target URL
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:27:05Z
-- **Updated:** 2026-06-08T10:27:05Z
+- **Updated:** 2026-06-29T16:10:56Z
 - **Labels:** None
 
 ---

--- a/issues/issue_22.md
+++ b/issues/issue_22.md
@@ -1,8 +1,8 @@
 # Issue #22: screenshotmachine is misclassified as contact=none even though the provider fetches target URLs
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:27:07Z
-- **Updated:** 2026-06-08T10:27:07Z
+- **Updated:** 2026-06-29T16:10:58Z
 - **Labels:** None
 
 ---

--- a/issues/issue_23.md
+++ b/issues/issue_23.md
@@ -1,8 +1,8 @@
 # Issue #23: microlink is misclassified as contact=none even though it fetches and screenshots target URLs
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:27:08Z
-- **Updated:** 2026-06-08T10:27:08Z
+- **Updated:** 2026-06-29T16:11:01Z
 - **Labels:** None
 
 ---

--- a/issues/issue_24.md
+++ b/issues/issue_24.md
@@ -1,8 +1,8 @@
 # Issue #24: pages_dev_meta is misclassified as contact=none even though Microlink fetches the submitted target URL
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:27:10Z
-- **Updated:** 2026-06-08T10:27:10Z
+- **Updated:** 2026-06-29T16:11:03Z
 - **Labels:** None
 
 ---

--- a/issues/issue_25.md
+++ b/issues/issue_25.md
@@ -1,8 +1,8 @@
 # Issue #25: exif_remove_lookup is misclassified as contact=none even though the provider fetches the submitted image URL
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:27:12Z
-- **Updated:** 2026-06-08T10:34:12Z
+- **Updated:** 2026-06-29T16:11:05Z
 - **Labels:** None
 
 ---

--- a/issues/issue_26.md
+++ b/issues/issue_26.md
@@ -1,8 +1,8 @@
 # Issue #26: Unauthenticated /api/intel/resolve leaks cross-run intelligence and can spend VirusTotal quota
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:31:46Z
-- **Updated:** 2026-06-08T10:31:46Z
+- **Updated:** 2026-06-29T16:13:58Z
 - **Labels:** None
 
 ---

--- a/issues/issue_27.md
+++ b/issues/issue_27.md
@@ -1,8 +1,8 @@
 # Issue #27: Unauthenticated /api/intel/graph exposes the persistent intelligence graph through arbitrary read-only Cypher
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:31:48Z
-- **Updated:** 2026-06-08T10:31:48Z
+- **Updated:** 2026-06-29T16:14:00Z
 - **Labels:** None
 
 ---

--- a/issues/issue_28.md
+++ b/issues/issue_28.md
@@ -1,8 +1,8 @@
 # Issue #28: /api/intel/graph accepts arbitrary expensive Cypher with no server-side timeout or enforced row cap
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:31:49Z
-- **Updated:** 2026-06-08T10:31:49Z
+- **Updated:** 2026-06-29T16:14:02Z
 - **Labels:** None
 
 ---

--- a/issues/issue_29.md
+++ b/issues/issue_29.md
@@ -1,8 +1,8 @@
 # Issue #29: Unauthenticated /api/intel/stats leaks corpus size and internal database paths
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:31:51Z
-- **Updated:** 2026-06-08T10:31:51Z
+- **Updated:** 2026-06-29T16:14:04Z
 - **Labels:** None
 
 ---

--- a/issues/issue_3.md
+++ b/issues/issue_3.md
@@ -1,8 +1,8 @@
 # Issue #3: Unauthenticated DELETE /api/cases/<id> lets any caller destroy persisted investigations
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:36Z
-- **Updated:** 2026-06-08T10:26:36Z
+- **Updated:** 2026-06-29T15:48:45Z
 - **Labels:** None
 
 ---

--- a/issues/issue_30.md
+++ b/issues/issue_30.md
@@ -1,8 +1,8 @@
 # Issue #30: Unauthenticated /api/transform/run turns resolver, VirusTotal, GitHub, and breach lookups into a public enrichment relay
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:31:52Z
-- **Updated:** 2026-06-08T10:31:52Z
+- **Updated:** 2026-06-29T16:14:06Z
 - **Labels:** None
 
 ---

--- a/issues/issue_31.md
+++ b/issues/issue_31.md
@@ -1,8 +1,8 @@
 # Issue #31: Public /api/osiris/* endpoints turn the deployment into an unauthenticated third-party reconnaissance relay
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:31:54Z
-- **Updated:** 2026-06-08T10:31:54Z
+- **Updated:** 2026-06-29T16:14:08Z
 - **Labels:** None
 
 ---

--- a/issues/issue_32.md
+++ b/issues/issue_32.md
@@ -1,8 +1,8 @@
 # Issue #32: [CRITICAL] #3: Unsafe LLM timeout handling causes race condition
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:35:04Z
-- **Updated:** 2026-06-08T10:35:04Z
+- **Updated:** 2026-06-29T16:15:32Z
 - **Labels:** None
 
 ---

--- a/issues/issue_33.md
+++ b/issues/issue_33.md
@@ -1,8 +1,8 @@
 # Issue #33: Real OSINT investigation data (IPs, domains) committed to git in reports/bundle_1780871293.json
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:42:27Z
-- **Updated:** 2026-06-08T11:42:27Z
+- **Updated:** 2026-06-29T16:16:06Z
 - **Labels:** None
 
 ---

--- a/issues/issue_34.md
+++ b/issues/issue_34.md
@@ -1,8 +1,8 @@
 # Issue #34: Stored XSS via unescaped entity.type field in innerHTML template literals
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:42:31Z
-- **Updated:** 2026-06-08T11:42:31Z
+- **Updated:** 2026-06-29T16:18:05Z
 - **Labels:** None
 
 ---

--- a/issues/issue_35.md
+++ b/issues/issue_35.md
@@ -1,8 +1,8 @@
 # Issue #35: /api/graph, /api/status, and all /api/discover/* endpoints are missing rate limiting
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:42:35Z
-- **Updated:** 2026-06-08T11:42:35Z
+- **Updated:** 2026-06-29T16:19:17Z
 - **Labels:** None
 
 ---

--- a/issues/issue_36.md
+++ b/issues/issue_36.md
@@ -1,8 +1,8 @@
 # Issue #36: Bare int() casts on user-controlled query parameters cause unhandled ValueError (500) on four endpoints
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:42:44Z
-- **Updated:** 2026-06-08T11:42:44Z
+- **Updated:** 2026-06-29T16:14:11Z
 - **Labels:** None
 
 ---

--- a/issues/issue_37.md
+++ b/issues/issue_37.md
@@ -1,8 +1,8 @@
 # Issue #37: Reddit sources scrape the JSON API without OAuth, violating Reddit's ToS and causing IP blocking
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:42:49Z
-- **Updated:** 2026-06-08T11:42:49Z
+- **Updated:** 2026-06-29T16:20:30Z
 - **Labels:** None
 
 ---

--- a/issues/issue_38.md
+++ b/issues/issue_38.md
@@ -1,8 +1,8 @@
 # Issue #38: In-process rate limiter is multiplied by gunicorn worker count — effective limit is N_workers × 30/min
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:42:53Z
-- **Updated:** 2026-06-08T11:42:53Z
+- **Updated:** 2026-06-29T16:21:46Z
 - **Labels:** None
 
 ---

--- a/issues/issue_39.md
+++ b/issues/issue_39.md
@@ -1,8 +1,8 @@
 # Issue #39: GitHub Actions workflow is a non-functional demo; Dependabot is misconfigured with an empty package-ecosystem
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:42:58Z
-- **Updated:** 2026-06-08T11:42:58Z
+- **Updated:** 2026-06-29T16:22:16Z
 - **Labels:** None
 
 ---

--- a/issues/issue_4.md
+++ b/issues/issue_4.md
@@ -1,8 +1,8 @@
 # Issue #4: Unauthenticated POST /api/cases/<id>/save lets any caller overwrite case notes
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:38Z
-- **Updated:** 2026-06-08T10:26:38Z
+- **Updated:** 2026-06-29T15:49:53Z
 - **Labels:** None
 
 ---

--- a/issues/issue_40.md
+++ b/issues/issue_40.md
@@ -1,8 +1,8 @@
 # Issue #40: All dependencies are unpinned (>=only) with no lockfile; multiple CVE ranges are reachable (aiohttp, gunicorn)
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:02Z
-- **Updated:** 2026-06-08T11:43:02Z
+- **Updated:** 2026-06-29T16:23:37Z
 - **Labels:** None
 
 ---

--- a/issues/issue_41.md
+++ b/issues/issue_41.md
@@ -1,8 +1,8 @@
 # Issue #41: CSP includes style-src 'unsafe-inline', enabling CSS injection and data exfiltration from intelligence reports
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:06Z
-- **Updated:** 2026-06-08T11:43:06Z
+- **Updated:** 2026-06-29T16:18:07Z
 - **Labels:** None
 
 ---

--- a/issues/issue_42.md
+++ b/issues/issue_42.md
@@ -1,8 +1,8 @@
 # Issue #42: _multi_test.sh hardcodes developer's home directory path, breaking all end-to-end tests for every other user
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:11Z
-- **Updated:** 2026-06-08T11:43:11Z
+- **Updated:** 2026-06-29T16:24:51Z
 - **Labels:** None
 
 ---

--- a/issues/issue_43.md
+++ b/issues/issue_43.md
@@ -1,8 +1,8 @@
 # Issue #43: /api/export/<fmt> creates permanent unbounded files in reports/ — unauthenticated disk exhaustion attack
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:16Z
-- **Updated:** 2026-06-08T11:43:16Z
+- **Updated:** 2026-06-29T16:28:03Z
 - **Labels:** None
 
 ---

--- a/issues/issue_44.md
+++ b/issues/issue_44.md
@@ -1,8 +1,8 @@
 # Issue #44: Internal exception details (file paths, schema names, query fragments) returned to unauthenticated API clients
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:21Z
-- **Updated:** 2026-06-08T11:43:21Z
+- **Updated:** 2026-06-29T16:29:55Z
 - **Labels:** None
 
 ---

--- a/issues/issue_45.md
+++ b/issues/issue_45.md
@@ -1,8 +1,8 @@
 # Issue #45: WiGLE source references non-existent env var WIGLE_API_NAME_WIGLE_API_API_KEY — source never authenticates
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:26Z
-- **Updated:** 2026-06-08T11:43:26Z
+- **Updated:** 2026-06-29T16:31:18Z
 - **Labels:** None
 
 ---

--- a/issues/issue_46.md
+++ b/issues/issue_46.md
@@ -1,8 +1,8 @@
 # Issue #46: Latent Cypher injection in KuzuGraphBackend.neighbors() via unsanitised relation parameter
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:30Z
-- **Updated:** 2026-06-08T11:43:30Z
+- **Updated:** 2026-06-29T16:32:50Z
 - **Labels:** None
 
 ---

--- a/issues/issue_47.md
+++ b/issues/issue_47.md
@@ -1,8 +1,8 @@
 # Issue #47: /api/graph serves the last operator's full intelligence graph without authentication or session isolation
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:35Z
-- **Updated:** 2026-06-08T11:43:35Z
+- **Updated:** 2026-06-29T16:32:58Z
 - **Labels:** None
 
 ---

--- a/issues/issue_48.md
+++ b/issues/issue_48.md
@@ -1,8 +1,8 @@
 # Issue #48: Audit log (data/audit.jsonl) has no rotation, size cap, or retention policy — unbounded growth and privacy risk
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:40Z
-- **Updated:** 2026-06-08T11:43:40Z
+- **Updated:** 2026-06-29T16:35:49Z
 - **Labels:** None
 
 ---

--- a/issues/issue_49.md
+++ b/issues/issue_49.md
@@ -1,8 +1,8 @@
 # Issue #49: estorides_core/config.py creates filesystem directories at module import time — violates project's own hard rules
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:44Z
-- **Updated:** 2026-06-08T11:43:44Z
+- **Updated:** 2026-06-29T16:38:34Z
 - **Labels:** None
 
 ---

--- a/issues/issue_5.md
+++ b/issues/issue_5.md
@@ -1,8 +1,8 @@
 # Issue #5: Unauthenticated /api/cases/diff reveals deltas between arbitrary investigations
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:40Z
-- **Updated:** 2026-06-08T10:26:40Z
+- **Updated:** 2026-06-29T15:50:56Z
 - **Labels:** None
 
 ---

--- a/issues/issue_50.md
+++ b/issues/issue_50.md
@@ -1,8 +1,8 @@
 # Issue #50: RUN_STREAM_JOBS and DISCOVER_JOBS hold BufferedEventSink objects indefinitely — memory exhaustion via sustained job creation
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T11:43:49Z
-- **Updated:** 2026-06-08T11:43:49Z
+- **Updated:** 2026-06-29T16:06:45Z
 - **Labels:** None
 
 ---

--- a/issues/issue_6.md
+++ b/issues/issue_6.md
@@ -1,8 +1,8 @@
 # Issue #6: Shared global GraphML file lets /api/graph disclose the last user's investigation
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:41Z
-- **Updated:** 2026-06-08T10:26:41Z
+- **Updated:** 2026-06-29T15:52:04Z
 - **Labels:** None
 
 ---

--- a/issues/issue_7.md
+++ b/issues/issue_7.md
@@ -1,8 +1,8 @@
 # Issue #7: Unauthenticated /api/export/<fmt> lets any caller download shared investigation artifacts
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:43Z
-- **Updated:** 2026-06-08T10:26:43Z
+- **Updated:** 2026-06-29T15:53:12Z
 - **Labels:** None
 
 ---

--- a/issues/issue_8.md
+++ b/issues/issue_8.md
@@ -1,8 +1,8 @@
 # Issue #8: Encrypted export leaves plaintext intelligence artifacts on disk in reports/
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:45Z
-- **Updated:** 2026-06-08T10:26:45Z
+- **Updated:** 2026-06-29T15:55:44Z
 - **Labels:** None
 
 ---

--- a/issues/issue_9.md
+++ b/issues/issue_9.md
@@ -1,8 +1,8 @@
 # Issue #9: Unauthenticated /api/run allows arbitrary callers to burn paid-source keys and upstream quota
 
-- **State:** open
+- **State:** closed
 - **Created:** 2026-06-08T10:26:46Z
-- **Updated:** 2026-06-08T10:26:46Z
+- **Updated:** 2026-06-29T15:56:48Z
 - **Labels:** None
 
 ---


### PR DESCRIPTION
Automated security export generated on 20260629_131848.

This PR adds a snapshot under `issues/` with:
- All GitHub issues (open + closed) as `issue_<n>.md`
- Open Dependabot alerts under `issues/dependabot/`
- Open Code Scanning alerts under `issues/codescan/`
- Index in `issues/README.md`

Generated by `security_issue_progressive.sh`.